### PR TITLE
Fix Call to undefined method NV\Theme::archive_nav()

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -9,9 +9,9 @@
 ?>
     <div id="container" class="archive row">
         <div id="content" class="small-12 large-8 columns">
-            <?php \NV\Theme::archive_nav(array('id' => 'nav-top')) ?>
+            <?php \NV\Theme::article_page_nav(array('id' => 'nav-top')) ?>
             <?php \NV\Theme::loop( 'parts/article' , 'parts/article-empty' ) ?>
-            <?php \NV\Theme::archive_nav(array('id' => 'nav-bottom')) ?>
+            <?php \NV\Theme::article_page_nav(array('id' => 'nav-bottom')) ?>
         </div>
         <div id="sidebar" class="small-12 large-4 columns">
             <?php dynamic_sidebar('sidebar-1') ?>

--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@
 ?>
     <div id="container" class="row">
         <div id="content" class="small-12 large-8 columns">
-            <?php \NV\Theme::archive_nav(array('id' => 'nav-top')) ?>
+            <?php \NV\Theme::article_page_nav(array('id' => 'nav-top')) ?>
 
             <?php \NV\Theme::loop( 'parts/article', 'parts/article-empty' ) ?>
 


### PR DESCRIPTION
Looks like archive_nav was renamed at some point to article_page_nav? I was getting undefined method on a new install while testing out Nouveau.
